### PR TITLE
docs: fix keptn task example link

### DIFF
--- a/content/en/docs/concepts/tasks/_index.md
+++ b/content/en/docs/concepts/tasks/_index.md
@@ -51,7 +51,7 @@ spec:
       url: <url>
 ```
 
-An example is available [here](./examples/taskonly-hello-keptn/http/taskdefinition.yaml).
+An example is available [here](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
 
 Finally, `KeptnTaskDefinition` can build on top of other `KeptnTaskDefinition`s.
 This is a common use case where a general function can be re-used in multiple places with different parameters.


### PR DESCRIPTION
Signed-off-by: Shardul Srivastava <shardul.srivastava007@gmail.com>

Fix the Ketpn `KeptnTaskDefinition` link. fixes https://github.com/keptn/lifecycle-toolkit/issues/679