### PR TITLE
chore: fixing module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keptn-sandbox/keptn-lifecycle-toolkit-docs
+module github.com/keptn-sandbox/lifecycle-toolkit-docs
 
 go 1.19
 


### PR DESCRIPTION
The module name was not correct, with this patch we reflect the actual module name based on github repo name